### PR TITLE
CIF-1133 - Add example to store the schema using aio-lib

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
         'header'
     ],
     'parserOptions': {
-        'ecmaVersion': 6
+        'ecmaVersion': 2017
     },
     'extends': 'eslint:recommended',
     'rules': {

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .nyc_output
 coverage
 results.xml
+test/*.cache

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In order to illustrate these requirements, the `localSchema()` function in [disp
 
 ## Caching
 
-For performance reasons, the [dispatcher.js](src/local/dispatcher.js) implementation "caches" the GraphQL schema in a global variable, so that further WARM invocations of the same action can immediately reuse the schema previously built with schema stitching. The Adobe I/O Runtime platform indeed reuses existing `Node.js` containers when possible, so it is posible to "cache" data in global variables.
+For performance reasons, the [dispatcher.js](src/local/dispatcher.js) implementation "caches" the GraphQL schema in a global variable, so that further WARM invocations of the same action can immediately reuse the schema previously built with schema stitching. The Adobe I/O Runtime platform indeed reuses existing `Node.js` containers when possible, so it is possible to "cache" data in global variables.
 
 In addition, the dispatcher implementation also demonstrates the use of the [aio-lib-state](https://github.com/adobe/aio-lib-state) library in order to cache all the remote schemas in a cache maintained by the Adobe I/O platform. This cache is used a second-level caching layer when a COLD container is used. The benefit of this caching layer increases with the number of remote resolvers, and the lifetime of this cached data is currently one hour. This caching is activated/disabled by the `use-aio-cache` property set in [serverless.yml](serverless.yml). During development, we **strongly recommend** that this property is set to `false` to make sure that changes to the schema are immediately visible in the schema.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ In order to illustrate these requirements, the `localSchema()` function in [disp
 
 For performance reasons, the [dispatcher.js](src/local/dispatcher.js) implementation "caches" the GraphQL schema in a global variable, so that further WARM invocations of the same action can immediately reuse the schema previously built with schema stitching. The Adobe I/O Runtime platform indeed reuses existing `Node.js` containers when possible, so it is possible to "cache" data in global variables.
 
-In addition, the dispatcher implementation also demonstrates the use of the [aio-lib-state](https://github.com/adobe/aio-lib-state) library in order to cache all the remote schemas in a cache maintained by the Adobe I/O platform. This cache is used a second-level caching layer when a COLD container is used. The benefit of this caching layer increases with the number of remote resolvers, and the lifetime of this cached data is currently one hour. This caching is activated/disabled by the `use-aio-cache` property set in [serverless.yml](serverless.yml). During development, we **strongly recommend** that this property is set to `false` to make sure that changes to the schema are immediately visible in the schema.
+In addition, the dispatcher implementation also demonstrates the use of the [aio-lib-state](https://github.com/adobe/aio-lib-state) library in order to cache all the remote schemas in a cache maintained by the Adobe I/O platform. This cache is used a second-level caching layer when a COLD container is used. The benefit of this caching layer increases with the number of remote resolvers, and the lifetime of this cached data is currently one hour.
+
+This caching is activated/disabled by the `use-aio-cache` property set in [serverless.yml](serverless.yml). To activate the caching, set this property to an integer value that will define the caching duration in seconds. During development, we **strongly recommend** that this property is set to `false` to make sure that changes to the schema are immediately visible in the schema.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ This repository provides a reference implementation that can be used as a starti
 * modify all the `__convertData` conversion methods in the data classes, to convert the data from the 3rd-party system into Magento GraphQL objects
 * modify and extend the `getter` methods in the data classes, to support all the fields not covered by the example integration
 * introduce new local and/or remote resolvers, to incrementally support more fields of the Magento GraphQL API
+* modify the GraphQL schema to only expose the implemented fields and any potential schema customization(s) and/or extension(s)
+
+## Schema customization and/or extension
+
+With GraphQL introspection, it is very easy for users to discover and browse a GraphQL schema in order to understand the types of queries it supports. Since the goal of the 3rd-party integration is to adapt the Magento GraphQL schema to "non-Magento" e-commerce platforms, it is clear that:
+* it is not realistic to expect that the entire Magento schema can be adapted at once
+* there might be incompabilities between the Magento GraphQL and a 3rd-party platform
+* it must be possible to extend the base Magento schema with custom attributes and fields
+
+In order to illustrate these requirements, the `localSchema()` function in [dispatcher.js](src/local/dispatcher.js) demonstrates a number of possible changes applied to the GraphQL schema. This is of course only an example, and a real implementation should either remove all the customizations if none if needed, or adapt the examples to satisfy the customizations and extensions required by the real integration. We however recommend that a real implementation should remove all the fields that it doesn't implement (at least for the top-level fields under the `Query` and `Mutation` root types), so that the schema only contains the parts of the Magento schema that are really implemented and supported.
+
+## Caching
+
+For performance reasons, the [dispatcher.js](src/local/dispatcher.js) implementation "caches" the GraphQL schema in a global variable, so that further WARM invocations of the same action can immediately reuse the schema previously built with schema stitching. The Adobe I/O Runtime platform indeed reuses existing `Node.js` containers when possible, so it is posible to "cache" data in global variables.
+
+In addition, the dispatcher implementation also demonstrates the use of the [aio-lib-state](https://github.com/adobe/aio-lib-state) library in order to cache all the remote schemas in a cache maintained by the Adobe I/O platform. This cache is used a second-level caching layer when a COLD container is used. The benefit of this caching layer increases with the number of remote resolvers, and the lifetime of this cached data is currently one hour. This caching is activated/disabled by the `use-aio-cache` property set in [serverless.yml](serverless.yml). During development, we **strongly recommend** that this property is set to `false` to make sure that changes to the schema are immediately visible in the schema.
 
 ### Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,106 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@adobe/aio-lib-core-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-core-errors/-/aio-lib-core-errors-3.0.0.tgz",
+      "integrity": "sha512-aBHCPZZpwB7yP8jSCHBGipTVKZBufjS7/qH5fSbJddn6p1sLKH4tEFTtbnFKIAGQ0fl99WZq8pkEzoqrHmf98w=="
+    },
+    "@adobe/aio-lib-core-logging": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-core-logging/-/aio-lib-core-logging-0.0.4.tgz",
+      "integrity": "sha512-ZR91xh7jFKD8RCQNmoMyrHumzeScZVWEYQ24zt6OvpY58xDnn0TGQFs4V2e0kmV579oHMTp5yNk0hTSueeW2uw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@adobe/aio-lib-core-tvm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-core-tvm/-/aio-lib-core-tvm-1.0.1.tgz",
+      "integrity": "sha512-Wrv36rLbmMdQFVhi8sJ+RYxm8nPhz2tusP3UdslMVlWj5Hc9f2tvhf0IO/yTd+KNxmmorUqQewa07v6ta5i2PQ==",
+      "requires": {
+        "@adobe/aio-lib-core-errors": "^3.0.0",
+        "@adobe/aio-lib-core-logging": "0.0.4",
+        "@hapi/joi": "^16.1.7",
+        "fs-extra": "^8.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "node-fetch": "^2.6.0",
+        "upath": "^1.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
+    "@adobe/aio-lib-state": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-state/-/aio-lib-state-1.0.2.tgz",
+      "integrity": "sha512-wezSaw/ikhUWIeB7DNEwGbX9tfCBjx5cYnoonIg8wMwhJA5nIhmPr+fiwF+YzI7Rs3UtnP/HE8sTO0WaW/1QOg==",
+      "requires": {
+        "@adobe/aio-lib-core-errors": "^3.0.0",
+        "@adobe/aio-lib-core-logging": "0.0.4",
+        "@adobe/aio-lib-core-tvm": "^1.0.0",
+        "@azure/cosmos": "^3.3.6",
+        "@hapi/joi": "^16.1.7",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "@azure/cosmos": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.4.2.tgz",
+      "integrity": "sha512-dj0sR8xVv99wXcrEvnHzIFDj1d/4yV+koLih3g9k5Ec+SB405eZdp1O73oo7T4Jc00g/bY7eSC7vzNy+4D6DWw==",
+      "requires": {
+        "@types/debug": "^4.1.4",
+        "debug": "^4.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "node-abort-controller": "^1.0.4",
+        "node-fetch": "^2.6.0",
+        "os-name": "^3.1.0",
+        "priorityqueuejs": "^1.0.0",
+        "semaphore": "^1.0.5",
+        "tslib": "^1.9.3",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -127,6 +227,46 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+    },
+    "@hapi/joi": {
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+      "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+      "requires": {
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "@serverless/cli": {
@@ -347,6 +487,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/lodash": {
       "version": "4.14.142",
@@ -1668,11 +1813,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1680,14 +1833,35 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1877,8 +2051,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cp-file": {
       "version": "6.2.0",
@@ -2270,6 +2443,16 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2425,6 +2608,14 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -2444,7 +2635,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2471,6 +2661,11 @@
           }
         }
       }
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -3149,6 +3344,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3157,6 +3357,11 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -3549,7 +3754,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -3633,8 +3837,7 @@
     "graceful-fs": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
-      "dev": true
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -3975,8 +4178,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -4246,8 +4448,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -4273,14 +4474,12 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "iso8601-duration": {
       "version": "1.2.0",
@@ -4542,7 +4741,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -4593,6 +4791,14 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
       }
     },
     "latest-version": {
@@ -4764,8 +4970,12 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.difference": {
       "version": "4.5.0",
@@ -4812,6 +5022,18 @@
         "chalk": "^2.0.1"
       }
     },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "lolex": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
@@ -4848,6 +5070,11 @@
       "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
       "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=",
       "dev": true
+    },
+    "macos-release": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -5507,8 +5734,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
       "version": "1.5.2",
@@ -5539,6 +5765,11 @@
           }
         }
       }
+    },
+    "node-abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-7cNtLKTAg0LrW3ViS2C7UfIzbL3rZd8L0++5MidbKqQVJ8yrH6+1VRSHl33P0ZjBTbOJd37d9EYekvHyKkB0QQ=="
     },
     "node-dir": {
       "version": "0.1.17",
@@ -5675,7 +5906,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -5899,10 +6129,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "2.0.1",
@@ -6029,6 +6263,15 @@
         }
       }
     },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -6056,8 +6299,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
@@ -6222,8 +6464,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-loader": {
       "version": "1.0.10",
@@ -6354,6 +6595,11 @@
         "lodash": "4.17.x"
       }
     },
+    "priorityqueuejs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+      "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -6363,8 +6609,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6430,7 +6675,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6590,7 +6834,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6604,8 +6847,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -6858,11 +7100,15 @@
         }
       }
     },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -7204,7 +7450,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -7212,8 +7457,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shortid": {
       "version": "2.2.15",
@@ -7227,8 +7471,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-git": {
       "version": "1.126.0",
@@ -7247,6 +7490,21 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        }
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -7580,8 +7838,7 @@
     "stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
-      "dev": true
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -7763,7 +8020,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -7771,8 +8027,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -7803,8 +8058,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -8141,6 +8395,11 @@
         "require-main-filename": "^2.0.0"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8288,6 +8547,11 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-invariant": {
       "version": "0.4.4",
@@ -8485,8 +8749,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -8549,8 +8812,7 @@
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "update-notifier": {
       "version": "2.5.0",
@@ -8636,8 +8898,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -8810,7 +9071,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8831,12 +9093,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8851,17 +9115,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8978,7 +9245,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8990,6 +9258,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9004,6 +9273,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9011,12 +9281,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9035,6 +9307,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9115,7 +9388,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9127,6 +9401,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9212,7 +9487,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9248,6 +9524,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9267,6 +9544,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9310,12 +9588,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9453,7 +9733,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -9480,6 +9759,87 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "requires": {
+        "execa": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
       }
     },
     "wordwrap": {
@@ -9547,8 +9907,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dataloader": "^1.4.0",
     "graphql": "^14.5.8",
     "graphql-tools": "3.1.1",
-    "openwhisk": "^3.19.0"
+    "openwhisk": "^3.19.0",
+    "@adobe/aio-lib-state": "^1.0.2"
   },
   "devDependencies": {
     "serverless": "^1.49.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ functions:
     annotations:
       web-export: true
     parameters:
-      use-aio-cache: true
+      use-aio-cache: 3600 # number of seconds for caching; set to false or remove to disable caching
       remoteSchemas: # Action with smaller order has "merge priority" in schema conflicts
         cart:
           order: 20

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,7 @@ functions:
     annotations:
       web-export: true
     parameters:
+      use-aio-cache: true
       remoteSchemas: # Action with smaller order has "merge priority" in schema conflicts
         cart:
           order: 20

--- a/src/local/dispatcher.js
+++ b/src/local/dispatcher.js
@@ -36,7 +36,7 @@ async function resolve(args) {
     let storeSchema = false; // If true, we will put the remote schemas in the aio-lib-state cache
 
     // If the schema is not cached, we try to get the remote schemas from the aio-lib-state cache
-    if (cachedSchema == null) {
+    if (cachedSchema == null && args['use-aio-cache']) {
         state = await libState.init();
         remoteResolvers = await fetchRemoteSchemasFromCache(state);
     }
@@ -45,7 +45,7 @@ async function resolve(args) {
     // we prepare the remote fetchers to build the executable remote schemas
     if (cachedSchema == null && args.remoteSchemas && remoteResolvers == null) {
         remoteResolvers = prepareRemoteSchemaFetchers(args.remoteSchemas);
-        storeSchema = true;
+        storeSchema = args['use-aio-cache'];
     }
     
     // The schema is already available, we use a NOOP Promise for Promise.all()
@@ -81,7 +81,7 @@ async function resolve(args) {
 
                 if (state && cachedSchemas.length > 0) {
                     console.debug('Trying to put schemas in aio-lib-state cache ...');
-                    await state.put('schemas', cachedSchemas);
+                    await state.put('schemas', cachedSchemas, {ttl: 3600});
                 }
             }
 

--- a/src/local/dispatcher.js
+++ b/src/local/dispatcher.js
@@ -36,7 +36,7 @@ async function resolve(args) {
     let storeSchema = false; // If true, we will put the remote schemas in the aio-lib-state cache
 
     // If the schema is not cached, we try to get the remote schemas from the aio-lib-state cache
-    if (cachedSchema == null && args['use-aio-cache']) {
+    if (cachedSchema == null && Number.isInteger(args['use-aio-cache'])) {
         state = await libState.init();
         remoteResolvers = await fetchRemoteSchemasFromCache(state);
     }
@@ -45,7 +45,7 @@ async function resolve(args) {
     // we prepare the remote fetchers to build the executable remote schemas
     if (cachedSchema == null && args.remoteSchemas && remoteResolvers == null) {
         remoteResolvers = prepareRemoteSchemaFetchers(args.remoteSchemas);
-        storeSchema = args['use-aio-cache'];
+        storeSchema = Number.isInteger(args['use-aio-cache']);
     }
     
     // The schema is already available, we use a NOOP Promise for Promise.all()
@@ -80,8 +80,9 @@ async function resolve(args) {
                 });
 
                 if (state && cachedSchemas.length > 0) {
-                    console.debug('Trying to put schemas in aio-lib-state cache ...');
-                    await state.put('schemas', cachedSchemas, {ttl: 3600});
+                    let ttl = args['use-aio-cache'];
+                    console.debug(`Trying to put schemas in aio-lib-state cache with ttl:${ttl} ...`);
+                    await state.put('schemas', cachedSchemas, {ttl});
                 }
             }
 

--- a/src/local/dispatcher.js
+++ b/src/local/dispatcher.js
@@ -16,7 +16,8 @@
 
 const magentoSchema = require('../resources/magento-schema-2.3.2.min.json');
 const { makeRemoteExecutableSchema, introspectSchema, mergeSchemas } = require('graphql-tools');
-const { graphql } = require('graphql');
+const { graphql, printSchema } = require('graphql');
+const libState = require('@adobe/aio-lib-state');
 
 const { Products, CategoryTree } = require('../common/Catalog.js');
 const ProductsLoader = require('../common/ProductsLoader.js');
@@ -24,33 +25,42 @@ const CategoryTreeLoader = require('../common/CategoryTreeLoader.js');
 const SchemaBuilder = require('../common/SchemaBuilder.js');
 const RemoteResolverFetcher = require('../common/RemoteResolverFetcher.js');
 
+// We cache the GraphQL schema in a global variable so that it is immediately available
+// if the same WARM container is reused in the Adobe I/O platform
 let cachedSchema = null;
 
-function resolve(args) {
+async function resolve(args) {
 
-    let remoteResolvers = [];
-    if (cachedSchema == null && args.remoteSchemas) {
-        // Get all resolver actions to fetch the remote schemas dynamically
-        remoteResolvers = Object.values(args.remoteSchemas).map(resolver => {
-            let fetcher = new RemoteResolverFetcher(resolver.action).fetcher;
-            return introspectSchema(fetcher).then(schema => {
-                return Promise.resolve({
-                    schema,
-                    fetcher,
-                    order: resolver.order
-                });
-            });
-        });
-    } else {
-        remoteResolvers.push(Promise.resolve({})); // Do nothing below
+    let remoteResolvers = null;
+    let state = null;        // The aio-lib-state object
+    let storeSchema = false; // If true, we will put the remote schemas in the aio-lib-state cache
+
+    // If the schema is not cached, we try to get the remote schemas from the aio-lib-state cache
+    if (cachedSchema == null) {
+        state = await libState.init();
+        remoteResolvers = await fetchRemoteSchemasFromCache(state);
     }
 
-    return Promise.all(remoteResolvers).then(remotes => {
+    // If the schema is not cached and we didn't get anything from the aio-lib-state cache,
+    // we prepare the remote fetchers to build the executable remote schemas
+    if (cachedSchema == null && args.remoteSchemas && remoteResolvers == null) {
+        remoteResolvers = prepareRemoteSchemaFetchers(args.remoteSchemas);
+        storeSchema = true;
+    }
+    
+    // The schema is already available, we use a NOOP Promise for Promise.all()
+    if (remoteResolvers == null) {
+        remoteResolvers = [Promise.resolve({})]; // Do nothing below
+    }
+
+    return Promise.all(remoteResolvers).then(async remotes => {
 
         if (cachedSchema == null) {
             let remoteExecutableSchemas = [localSchema()];
 
             if (args.remoteSchemas) {
+                let cachedSchemas = [];
+
                 remotes.forEach(remote => {
                     let remoteExecutableSchema = makeRemoteExecutableSchema({
                         schema: remote.schema,
@@ -58,21 +68,29 @@ function resolve(args) {
                     });
                     remoteExecutableSchema.sortOrder = remote.order;
                     remoteExecutableSchemas.push(remoteExecutableSchema);
-                });
-            }
 
-            // Keep schema types with lowest order
-            let onTypeConflict = (left, right, info) => {
-                let diff = info.left.schema.sortOrder - info.right.schema.sortOrder;
-                return (diff <= 0) ? left : right;
-            };
+                    // We store the remote schemas in SDL form in the aio-lib-state cache
+                    if (storeSchema) {
+                        cachedSchemas.push({
+                            schema: printSchema(remote.schema),
+                            action: remote.action,
+                            order: remote.order
+                        });
+                    }
+                });
+
+                if (state && cachedSchemas.length > 0) {
+                    console.debug('Trying to put schemas in aio-lib-state cache ...');
+                    await state.put('schemas', cachedSchemas);
+                }
+            }
 
             let finalSchema = mergeSchemas({
                 schemas: remoteExecutableSchemas,
                 onTypeConflict: onTypeConflict
             });
 
-            cachedSchema = finalSchema;
+            cachedSchema = finalSchema; // eslint-disable-line require-atomic-updates
         }
 
         // Passed to all resolver actions, can for example contain an authentication token
@@ -115,6 +133,58 @@ function resolve(args) {
     }).catch(error => {
         console.error(error);
     });
+}
+
+/**
+ * When merging schemas, this method keeps the data of the schema with lowest order.
+ * The parameters are automatically passed by the graphql-tools library.
+ */
+function onTypeConflict(left, right, info) {
+    let diff = info.left.schema.sortOrder - info.right.schema.sortOrder;
+    return (diff <= 0) ? left : right;
+}
+
+/**
+ * This method prepares the introspection calls that will be used to get all the remote schemas
+ * from all the remote actions.
+ * 
+ * @param {*} remoteSchemas The remote schemas configured in the dispatcher action.
+ */
+function prepareRemoteSchemaFetchers(remoteSchemas) {
+    // Get all resolver actions to fetch the remote schemas dynamically
+    return Object.values(remoteSchemas).map(resolver => {
+        console.debug(`--> Preparing remote schema fetcher for action ${resolver.action}`);
+        let fetcher = new RemoteResolverFetcher(resolver.action).fetcher;
+        return introspectSchema(fetcher).then(schema => {
+            return Promise.resolve({
+                schema,
+                fetcher,
+                order: resolver.order,
+                action: resolver.action
+            });
+        });
+    });
+}
+
+/**
+ * This method checks if the SDL remote schemas are available in the aio-lib-state cache.
+ * If successful, it returns an Array of remote resolvers that can be used to build the
+ * executable remote schemas. It returns null if nothing could be fetched from the cache.
+ */
+async function fetchRemoteSchemasFromCache(state) {
+    console.debug('Trying to get remote schemas from aio-lib-state cache ...');
+    let schemas = await state.get('schemas');
+    if (schemas) {
+        console.debug(`--> Got ${schemas.value.length} schemas from aio-lib-state cache`);
+        return schemas.value.map(obj => {
+            return Promise.resolve({
+                schema: obj.schema,
+                fetcher: new RemoteResolverFetcher(obj.action).fetcher,
+                order: obj.order
+            });
+        });
+    }
+    return null;
 }
 
 /**
@@ -174,4 +244,10 @@ function localSchema() {
     return schemaBuilder.build(10);
 }
 
+// Only exported for unit testing
+function cleanCachedSchema() {
+    cachedSchema = null;
+}
+
 module.exports.main = resolve;
+module.exports.cleanCacheSchema = cleanCachedSchema;

--- a/test/local/dispatcherTest.js
+++ b/test/local/dispatcherTest.js
@@ -109,7 +109,8 @@ describe('Dispatcher Resolver', () => {
                     order: 20,
                     action: '../../src/remote/cartResolver.js'
                 }
-            }
+            },
+            "use-aio-cache": true
         };
 
         it('Basic products search', () => {

--- a/test/local/dispatcherTest.js
+++ b/test/local/dispatcherTest.js
@@ -110,7 +110,7 @@ describe('Dispatcher Resolver', () => {
                     action: '../../src/remote/cartResolver.js'
                 }
             },
-            "use-aio-cache": true
+            "use-aio-cache": 3600
         };
 
         it('Basic products search', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,13 @@ module.exports = {
     devtool: 'source-map',
     target: 'node',
     stats: 'minimal',
+    mode: 'development',
     output: {
         libraryTarget: 'commonjs',
         path: path.resolve(__dirname, '.webpack'),
         filename: '[name].js'
+    },
+    optimization: {
+        minimize: false // Azure SDK in aio-lib-state fails when minified
     }
 };


### PR DESCRIPTION
## Motivation and Context

This PR adds some schema caching with the use of the `aio-lib-state` library. The objective is to be able to cache remote schemas in order to increase the performance of the GraphQL integration during COLD invocations of the actions.

## How Has This Been Tested?

Extended unit test by mocking the `aio-lib-state` library to put and get cached data in the filesystem.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code passes the code style as defined by ESLint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
